### PR TITLE
Replace python-nexus with commonnexus

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,13 +33,14 @@ package_dir =
     = src
 python_requires = >=3.7
 install_requires =
+    newick>=1.9
+    commonnexus
     cldfviz>=0.10
     pycldf>=1.33.0
     clldutils
     cldfbench>=1.10.0
     cldfcatalog
     attrs
-    python-nexus>=2.8.0
     pyglottolog>=3.9.0
     termcolor
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,10 +30,10 @@ zip_safe = False
 packages = find:
 package_dir =
     = src
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     newick>=1.9
-    commonnexus
+    commonnexus>=1.3
     cldfviz>=0.10
     pycldf>=1.33.0
     clldutils
@@ -106,7 +105,7 @@ show_missing = true
 skip_covered = true
 
 [tox:tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311
 isolated_build = true
 skip_missing_interpreter = true
 

--- a/src/phlorest/beast.py
+++ b/src/phlorest/beast.py
@@ -1,6 +1,8 @@
+import collections
 import xml.etree.cElementTree as ElementTree
 
-import nexus
+from commonnexus import Nexus
+from commonnexus.blocks import Characters
 
 __all__ = ['BeastFile']
 
@@ -9,72 +11,63 @@ class BeastFile:
     def __init__(self, path, text=None):
         self.path = path
         self.text = text
-
-    def nexus_and_characters(self):
-        return beast_to_nexus(self.path or self.text)
-
-
-def beast_to_nexus(filename, valid_states="01?"):
-    nex = nexus.NexusWriter()
-    if isinstance(filename, str):
-        xml = ElementTree.fromstring(filename)
-    else:
-        xml = ElementTree.parse(str(filename))
-    #
-    # <sequence>
-    # <taxon idref=""/>
-    # 1111111
-    # </sequence>
-    #
-    seq_found = False
-    for seq in xml.findall('./data/sequence'):
-        seq_found = True
-        for i, state in enumerate([s for s in seq.get('value') if s != ' '], start=1):
-            assert state in valid_states, 'Invalid State %s' % state
-            nex.add(seq.get('taxon'), i, state)
-
-    if not seq_found:
-        for seq in xml.findall('.//sequence[taxon]'):
-            data = (seq.text.strip() if seq.text else None) or seq.find('taxon').tail.strip()
-            assert data, ElementTree.tostring(seq).decode('utf8').replace('\n', '')
-            for i, state in enumerate(list(data), start=1):
-                assert state in valid_states, 'Invalid State %s' % state
-                nex.add(seq.find('taxon').get('idref'), i, state)
-
-    try:
-        chars = sorted(list(beast2chars(xml)))
-    except (ValueError, KeyError):  # pragma: no cover
-        chars = None
-    return nexus.NexusReader.from_string(nex.write()), chars
-
-
-def beast2chars(xml):
-    def get_partition(p):
-        x, y = [int(_) for _ in p.get('filter').split("-")]
-        return (p.get('id'), x, y)
-
-    def printchar(p, x, y, ascertained=False):
-        n = 1
-        for i in range(x, y + 1):
-            label = "%s-%s" % (p, 'ascertained' if n == 1 and ascertained else str(n))
-            yield i, label
-            n += 1
-
-    def get_by_id(data_id):
-        if data_id.startswith("@"):
-            data_id = data_id.lstrip("@")
-        res = xml.find(".//alignment[@id='%s']" % data_id)
-        if res is None:  # pragma: no cover
-            raise ValueError(data_id)
-        return res
-
-    for treelh in xml.findall(".//distribution[@spec='TreeLikelihood']"):
-        if treelh.get('data'):
-            data = get_by_id(treelh.get('data'))
-            ascertained = data.get('ascertained') == 'true'
-            yield from printchar(*get_partition(data.find('./data')), ascertained=ascertained)
+        if self.text:
+            self.xml = ElementTree.fromstring(self.text)
         else:
-            data = treelh.find('./data')
-            ascertained = data.get('ascertained') == 'true'
-            dd = get_by_id(data.get('data')) if data.get('data') else treelh.find('./data/data')
-            yield from printchar(*get_partition(dd), ascertained=ascertained)
+            self.xml = ElementTree.parse(str(self.path))
+
+    def nexus(self, valid_states='01?') -> Nexus:
+        try:  # Read the character labels.
+            chars = dict(self.iter_characters())
+        except (ValueError, KeyError):  # pragma: no cover
+            chars = {}  # No character labels.
+
+        matrix = collections.OrderedDict()
+
+        def add_row(taxon, seq):
+            matrix[taxon] = collections.OrderedDict()
+            for i, state in enumerate([s for s in seq if s != ' '], start=1):
+                assert state in valid_states, 'Invalid State %s' % state
+                matrix[taxon][chars.get(i, str(i))] = None if state == '?' else state
+
+        for seq in self.xml.findall('./data/sequence'):
+            add_row(seq.get('taxon'), seq.get('value'))
+
+        if not matrix:
+            for seq in self.xml.findall('.//sequence[taxon]'):
+                data = (seq.text.strip() if seq.text else None) or seq.find('taxon').tail.strip()
+                assert data, ElementTree.tostring(seq).decode('utf8').replace('\n', '')
+                add_row(seq.find('taxon').attrib['idref'], data)
+
+        return Nexus.from_blocks(Characters.from_data(matrix))
+
+    def iter_characters(self):
+        def get_partition(p):
+            x, y = [int(_) for _ in p.get('filter').split("-")]
+            return (p.get('id'), x, y)
+
+        def printchar(p, x, y, ascertained=False):
+            n = 1
+            for i in range(x, y + 1):
+                label = "%s-%s" % (p, 'ascertained' if n == 1 and ascertained else str(n))
+                yield i, label
+                n += 1
+
+        def get_by_id(data_id):
+            if data_id.startswith("@"):
+                data_id = data_id.lstrip("@")
+            res = self.xml.find(".//alignment[@id='%s']" % data_id)
+            if res is None:  # pragma: no cover
+                raise ValueError(data_id)
+            return res
+
+        for treelh in self.xml.findall(".//distribution[@spec='TreeLikelihood']"):
+            if treelh.get('data'):
+                data = get_by_id(treelh.get('data'))
+                ascertained = data.get('ascertained') == 'true'
+                yield from printchar(*get_partition(data.find('./data')), ascertained=ascertained)
+            else:
+                data = treelh.find('./data')
+                ascertained = data.get('ascertained') == 'true'
+                dd = get_by_id(data.get('data')) if data.get('data') else treelh.find('./data/data')
+                yield from printchar(*get_partition(dd), ascertained=ascertained)

--- a/src/phlorest/beast.py
+++ b/src/phlorest/beast.py
@@ -1,3 +1,5 @@
+import typing
+import pathlib
 import collections
 import xml.etree.cElementTree as ElementTree
 
@@ -8,7 +10,7 @@ __all__ = ['BeastFile']
 
 
 class BeastFile:
-    def __init__(self, path, text=None):
+    def __init__(self, path: typing.Union[str, pathlib.Path], text: typing.Optional[str] = None):
         self.path = path
         self.text = text
         if self.text:
@@ -16,7 +18,14 @@ class BeastFile:
         else:
             self.xml = ElementTree.parse(str(self.path))
 
-    def nexus(self, valid_states='01?') -> Nexus:
+    def nexus(self, valid_states: str = '01?') -> Nexus:
+        """
+        Read the character data used in a BEAST file and format it as NEXUS file.
+
+        :param valid_states: String listing one-character state labels.
+        :return: A Nexus instance with a CHARACTERS block encoding the data from the BEAST file as \
+        MATRIX.
+        """
         try:  # Read the character labels.
             chars = dict(self.iter_characters())
         except (ValueError, KeyError):  # pragma: no cover

--- a/src/phlorest/cldfwriter.py
+++ b/src/phlorest/cldfwriter.py
@@ -2,7 +2,6 @@ import typing
 import pathlib
 
 import cldfbench
-
 import newick
 import tqdm
 from pycldf.terms import TERMS
@@ -117,7 +116,11 @@ class CLDFWriter(cldfbench.CLDFWriter):
                     log,
                     source=None,
                     rooted=None):
-        self.add_tree(tree, self.summary, 'summary', metadata, log, 'summary', source=source, rooted=rooted)
+        """
+        Add `tree` as summary tree to the dataset.
+        """
+        self.add_tree(
+            tree, self.summary, 'summary', metadata, log, 'summary', source=source, rooted=rooted)
         log.info("added summary tree")
 
     def add_posterior(self,
@@ -127,6 +130,9 @@ class CLDFWriter(cldfbench.CLDFWriter):
                       source=None,
                       verbose=False,
                       rooted=None):
+        """
+        Add `trees` as posterior sample of trees to the dataset.
+        """
         i = 0
         for i, tree in (
                 tqdm.tqdm(enumerate(trees, start=1), total=len(trees))
@@ -142,7 +148,16 @@ class CLDFWriter(cldfbench.CLDFWriter):
                 rooted=rooted)
         log.info("added posterior trees (n=%d)" % i)
 
-    def add_data(self, input, characters, log):
+    def add_data(self,
+                 input: typing.Union[BeastFile, pathlib.Path, str, Nexus],
+                 characters: typing.Iterable[typing.Dict[str, str]], log):
+        """
+        Add character data from which the tree(s) in the dataset were computed.
+
+        :param input: Character data can be read from BEAST files and NEXUS files.
+        :param characters: Character metadata, per site.
+        :param log:
+        """
         if isinstance(input, BeastFile):
             nex = input.nexus()
         elif isinstance(input, pathlib.Path):
@@ -181,7 +196,8 @@ class CLDFWriter(cldfbench.CLDFWriter):
             'MediaTable',
             dict(ID='data', Media_Type='text/plain', Download_URL='file:///data.nex'))
 
-        assert all(t in self._lids for t in nex.taxa), "Taxa in nexus not in taxa.csv: {}".format([t for t in nex.taxa if t not in self._lids])
+        assert all(t in self._lids for t in nex.taxa), "Taxa in nexus not in taxa.csv: {}".format(
+            [t for t in nex.taxa if t not in self._lids])
 
         nex.to_file(self.cldf_spec.dir / 'data.nex')
         self.cldf.add_provenance(
@@ -194,7 +210,10 @@ class CLDFWriter(cldfbench.CLDFWriter):
         )
         log.info("added data nexus (characters=%d)" % len(charlabels))
 
-    def add_taxa(self, taxa, glottolog, log):
+    def add_taxa(self,
+                 taxa: typing.List[typing.Dict[str, str]],
+                 glottolog,
+                 log):
         glangs = {lg.id: lg for lg in glottolog.languoids()}
         #
         # FIXME: add metadata from Glottolog, put in dplace-tree-specific Dataset base class.

--- a/src/phlorest/nexuslib.py
+++ b/src/phlorest/nexuslib.py
@@ -23,7 +23,7 @@ def rescale_to_years(nex: Nexus, orig_scaling, log=None) -> Nexus:
     :return: The mutated `Nexus` object.
     """
     def _rescaler(factor, n):
-        n._length_formatter = lambda l: '{:.0f}'.format(l) if l else None
+        n._length_formatter = lambda lg: '{:.0f}'.format(lg) if lg else None
         if n._length:
             n.length = n.length * factor
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@ import shutil
 import pathlib
 
 import pytest
-from nexus.handlers.tree import Tree
 from pyglottolog import Glottolog
+
+from phlorest.nexuslib import Tree
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def repos():
 
 @pytest.fixture
 def nexus_tree():
-    return Tree('tree name = (A:45.5,B:34.7):56.5;')
+    return Tree('name' , '(A:45.5,B:34.7):56.5;', None)
 
 
 @pytest.fixture

--- a/tests/test_beast.py
+++ b/tests/test_beast.py
@@ -1,8 +1,19 @@
 from phlorest import BeastFile
 
-def test_BeastFile(dataset):
+
+def test_BeastFile_1(dataset):
     bf = BeastFile(None, text=dataset.raw_dir.read('beast2.xml.gz'))
-    nex, chars = bf.nexus_and_characters()
-    assert chars[135] == (136, 'again-62')  # check one
-    assert sorted(nex.data.taxa) == sorted(['A', 'B', 'C'])
-    assert len(chars) == nex.data.nchar == 235
+    nex = bf.nexus()
+    matrix = nex.characters.get_matrix()
+    assert list(matrix['A'])[135] == 'again-62'  # check one
+    assert sorted(nex.taxa) == ['A', 'B', 'C']
+    assert len(matrix['A']) == 235
+
+
+def test_BeastFile_2(dataset):
+    bf = BeastFile(None, text=dataset.raw_dir.read('beast.xml'))
+    nex = bf.nexus()
+    matrix = nex.characters.get_matrix()
+    assert nex.taxa == ['Jeju', 'SouthJeolla', 'NorthJeolla']
+    assert len(matrix['Jeju']) == 384
+    assert list(matrix['Jeju'])[1] == '2'  # no character labels

--- a/tests/test_cldfwriter.py
+++ b/tests/test_cldfwriter.py
@@ -29,3 +29,23 @@ def test_CLDFWriter_nexus_data(repos, tmp_path, mocker, nexus_tree, dataset, glo
         writer.add_taxa(dataset.taxa, glottolog, mocker.Mock())
         writer.add_data(repos / 'raw' / 'data.nex', [{'Site': '0', 'Gloss': 'abc'}], mocker.Mock())
         assert writer.cldf['ParameterTable', 'Gloss']
+
+
+def test_CLDFWriter_nexus_data_2(repos, tmp_path, mocker, nexus_tree, dataset, glottolog):
+    with CLDFWriter(cldf_spec=cldfbench.CLDFSpec(dir=tmp_path)) as writer:
+        writer.add_taxa(dataset.taxa, glottolog, mocker.Mock())
+        writer.add_data(
+            (repos / 'raw' / 'data.nex').read_text(encoding='utf8'),
+            [{'Site': '0', 'Gloss': 'abc'}], mocker.Mock())
+        assert writer.cldf['ParameterTable', 'Gloss']
+
+
+def test_CLDFWriter_nexus_data_3(repos, tmp_path, mocker, nexus_tree, dataset, glottolog):
+    from commonnexus import Nexus
+
+    with CLDFWriter(cldf_spec=cldfbench.CLDFSpec(dir=tmp_path)) as writer:
+        writer.add_taxa(dataset.taxa, glottolog, mocker.Mock())
+        writer.add_data(
+            Nexus((repos / 'raw' / 'data.nex').read_text(encoding='utf8')),
+            [{'Site': '0', 'Gloss': 'abc'}], mocker.Mock())
+        assert writer.cldf['ParameterTable', 'Gloss']

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -18,9 +18,12 @@ def test_PhlorestDir(repos):
     assert 'abcdefg' in str(nex)
 
 
-def test_PhlorestDir_remove_rate(repos):
+def test_PhlorestDir_with_rates(repos):
     d = PhlorestDir(repos / 'raw')
     nex = d.read_nexus('trees_with_rate.trees')
+    for node in nex.TREES.TREE.newick.walk():
+        if node.name == '1':
+            assert ('height' in node.properties) and ('rate' in node.properties)
 
 
 @pytest.mark.noci

--- a/tests/test_nexuslib.py
+++ b/tests/test_nexuslib.py
@@ -1,29 +1,26 @@
 import pytest
-import newick
-import nexus
-from nexus.handlers.tree import Tree
 
-from phlorest.nexuslib import NexusFile, newick2nexus, rescale_to_years
+from commonnexus import Nexus
+
+from phlorest.nexuslib import NexusFile, rescale_to_years, Tree
 
 
 def test_rescale_to_years():
-    nex = nexus.NexusWriter()
-    nex.trees.append(Tree('tree t1 = (A:258,B:123)C:254;'))
+    nex = Nexus("""#NEXUS
+begin trees;
+tree t1 = (A:258,B:123)C:254;
+end;""")
     res = rescale_to_years(nex, 'millennia')
-    assert '258000' in res.trees.trees[0].newick_string
+    assert '258000' in res.TREES.TREE.newick_string
 
     with pytest.raises(ValueError):
         _ = rescale_to_years(nex, 'millenia')
 
 
-def test_newick2nexus():
-    assert newick2nexus(newick.loads('(A,B)C;')[0], name='X') == 'tree X = (A,B)C;'
-
-
 def test_NexusFile(tmp_path, mocker):
     with NexusFile(tmp_path / 'test.nex') as nex:
-        nex.append(Tree('tree n = (A:1,B:2)root:3;'), 'a', {'A', 'B'}, 'years', mocker.Mock())
+        nex.append(Tree('n', '(A:1,B:2)root:3;', None), 'a', {'A', 'B'}, 'years', mocker.Mock())
         with pytest.raises(ValueError):
-            nex.append(Tree('tree n = (A:1,B:2)root:3;'), 'c', {'A', 'B'}, 'change', mocker.Mock())
-    res = nexus.NexusReader.from_file(tmp_path / 'test.nex')
-    assert res.trees.ntrees == 1
+            nex.append(Tree('n', '(A:1,B:2)root:3;', None), 'c', {'A', 'B'}, 'change', mocker.Mock())
+    res = Nexus.from_file(tmp_path / 'test.nex')
+    assert len(res.TREES.trees) == 1


### PR DESCRIPTION
Overall, I think this switch makes the code more readable (and robust). Because the `newick` package now handles multiple comments per node, we can also get rid of the "remove rate" functionality.