### PR TITLE
Check that the concepts in etc/characters.csv and cldf/parameters.csv are the same size

### DIFF
--- a/src/phlorest/check.py
+++ b/src/phlorest/check.py
@@ -76,6 +76,14 @@ def run_checks(d: typing.Union[CLDFDataset, Dataset], log) -> bool:
         success &= check(
             all(char.get('Concepticon_ID', "") == "" for char in d.characters),
             "characters.csv file missing concepticon coding")
+    
+    # check that we have the same number of entries in ./etc/characters.csv and ./cldf/parameters.csv
+    if d.characters:
+        try:
+            nparams = len(d.cldf_dir.read_csv('parameters.csv', dicts=True))
+        except FileNotFoundError:
+            nparams = 0
+        success &= check(nparams != len(d.characters), "characters.csv does not match parameters.csv")
 
     success &= check((d.dir / 'Makefile').exists(), "has a legacy Makefile")
     return success


### PR DESCRIPTION
I ran into a bug with the `kitchen_et_al2009` dataset where the wrong nexus was loaded leading to a mismatch between cldf/parameters.csv and the number of characters in the nexus (and ./etc/characters.csv). This checks for that glitch